### PR TITLE
close issue 171 in front

### DIFF
--- a/lib/add-sci-publication.js
+++ b/lib/add-sci-publication.js
@@ -68,12 +68,12 @@ validateDocInfo = async function(doc)
             error: "Year field must be a positive number between 1950 and current year"}
         if (doc.doi === null || doc.doi === undefined) return {
             error: "DOI field is mandatory"}
-        const title_exists = await doesTitleExist(doc.title,doc.id);
+        const title_exists = await doesTitleExist(doc.title, doc.sub_type, doc.id);
 
         if(title_exists)
         {
             return {
-                error: "Title already exists"
+                error: "Title already exists for this solution"
             }
         }
         // Validate DOI

--- a/lib/database.js
+++ b/lib/database.js
@@ -727,16 +727,17 @@ let updateData = function (data, id) {
  * @param {integer} id - The id of the publication
  * * @returns {Promise<boolean>} - Promise resolving to true if the title exists, false otherwise.
  */
-let doesTitleExist = async function (title,id = null) {
+let doesTitleExist = async function (title, sub_type, id = null) {
     return new Promise((resolve, reject) => {
         // The query to check if the title exists
         let query = `
             SELECT 1
             FROM sci_publications
             WHERE title = ?
+            AND sub_type = ?
             AND validation_status != 'deleted'
         `;
-        let data = [title];
+        let data = [title, sub_type];
         if(id)
         {
             query+=` AND id != ?`


### PR DESCRIPTION
Ens hem trobat que una publicació podia contenir més d'una tecnologia. Per no liar-la fent que el camp sub_type fos tipus array, perquè llavors calia modificar també els samples. He fet que es pugui duplicar el títol si és per una tecnologia diferent.

El tema de l'id no tinc molt clar perquè el feies servir, tampoc es crida d'enlloc més aquesta funció. En tot cas, comprova que no es trenqui el workflow en algun altre lloc.